### PR TITLE
Control backlight using sysfs

### DIFF
--- a/sparse/usr/lib/systemd/system/phosh.service.d/90-backlight.conf
+++ b/sparse/usr/lib/systemd/system/phosh.service.d/90-backlight.conf
@@ -1,0 +1,2 @@
+[Service]
+Environment=WLR_HWC_SYSFS_BACKLIGHT=1


### PR DESCRIPTION
Earlier, the backlight would not turn off when the screen was turned off, but I fixed this issue by directly controlling the backlight.